### PR TITLE
Bugfix: Add used field to MD5 hash state

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -1,0 +1,34 @@
+name: Unit tests
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        julia-version:
+          - '1.8'
+          - '1'
+        julia-arch: [x86]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        experimental: [false]
+        include:
+          - julia-version: nightly
+            julia-arch: x86
+            os: ubuntu-latest
+            experimental: true
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Setup Julia
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+      - name: Run Tests
+        uses: julia-actions/julia-runtest@latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MD5"
 uuid = "6ac74813-4b46-53a4-afec-0b5dc9d7885c"
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/types.jl
+++ b/src/types.jl
@@ -2,6 +2,7 @@ mutable struct MD5_CTX <: SHA_CTX
     state::Array{UInt32,1}
     bytecount::UInt64
     buffer::Array{UInt8,1}
+    used::Bool
 end
 
 digestlen(::Type{MD5_CTX}) = 16
@@ -9,10 +10,6 @@ state_type(::Type{MD5_CTX}) = UInt32
 # blocklen is the number of bytes of data processed by the transform!() function at once
 blocklen(::Type{MD5_CTX}) = UInt64(64)
 
-
-
-
-MD5_CTX() = MD5_CTX(copy(MD5_initial_hash_value), 0, zeros(UInt8, blocklen(MD5_CTX)))
+MD5_CTX() = MD5_CTX(copy(MD5_initial_hash_value), 0, zeros(UInt8, blocklen(MD5_CTX)), false)
 Base.copy(ctx::T) where {T<:MD5_CTX} = T(copy(ctx.state), ctx.bytecount, copy(ctx.buffer))
 Base.show(io::IO, ::MD5_CTX) = write(io, "MD5 hash state")
-


### PR DESCRIPTION
MD5.jl currently uses undocumented and unexported internals of the SHA stdlib. PR #86 to SHA.jl added a new field, `used` to the SHA states. Since MD5 uses internal SHA functions which now look for this field, MD5 tests began to fail.

This PR adds the needed `used` field, so MD5 now runs. The real fix is to not rely on SHA internals.

Closes #11 