### PR TITLE
Deprecate copy for deepcopy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MD5"
 uuid = "6ac74813-4b46-53a4-afec-0b5dc9d7885c"
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/MD5.jl
+++ b/src/MD5.jl
@@ -10,6 +10,7 @@ export md5
 include("constants.jl")
 include("types.jl")
 include("core.jl")
+include("deprecated.jl")
 
 
 # Our basic function is to process arrays of bytes

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,3 @@
+using Base: @deprecate
+import Base: copy
+@deprecate copy(ctx::MD5_CTX) deepcopy(ctx)

--- a/src/types.jl
+++ b/src/types.jl
@@ -11,5 +11,4 @@ state_type(::Type{MD5_CTX}) = UInt32
 blocklen(::Type{MD5_CTX}) = UInt64(64)
 
 MD5_CTX() = MD5_CTX(copy(MD5_initial_hash_value), 0, zeros(UInt8, blocklen(MD5_CTX)), false)
-Base.copy(ctx::T) where {T<:MD5_CTX} = T(copy(ctx.state), ctx.bytecount, copy(ctx.buffer))
 Base.show(io::IO, ::MD5_CTX) = write(io, "MD5 hash state")

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -1,0 +1,1 @@
+@test (@test_deprecated copy(MD5.MD5_CTX())) isa MD5.MD5_CTX

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,3 +30,4 @@ end
 
 include("nettle.jl")
 include("perf.jl")
+include("deprecated.jl")


### PR DESCRIPTION
Solves #17 
We were just reimplementing `deepcopy` anyway.

Will merge once CI passes
